### PR TITLE
Use types from specification

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -2,6 +2,10 @@
 
 package wasmgl
 
+// NOTE: The following constants do not have the GLenum type on purpose.
+// Certain constants need to be used as non-GLenum parameters (e.g.
+// when passing NEAREST / LINEAR / etc to TexParameteri).
+
 const (
 	// WebGL1 constants
 	// (https://www.khronos.org/registry/webgl/specs/latest/1.0/)

--- a/functions.go
+++ b/functions.go
@@ -115,6 +115,10 @@ var (
 	fnDeleteSync            js.Value
 	fnClientWaitSync        js.Value
 	fnGetSyncParameter      js.Value
+	fnBindBufferBase        js.Value
+	fnBindBufferRange       js.Value
+	fnGetUniformBlockIndex  js.Value
+	fnUniformBlockBinding   js.Value
 	fnCreateVertexArray     js.Value
 	fnDeleteVertexArray     js.Value
 	fnBindVertexArray       js.Value
@@ -216,6 +220,10 @@ func initFunctions(gl js.Value) {
 	fnDeleteSync = getFunction(gl, "deleteSync")
 	fnClientWaitSync = getFunction(gl, "clientWaitSync")
 	fnGetSyncParameter = getFunction(gl, "getSyncParameter")
+	fnBindBufferBase = getFunction(gl, "bindBufferBase")
+	fnBindBufferRange = getFunction(gl, "bindBufferRange")
+	fnGetUniformBlockIndex = getFunction(gl, "getUniformBlockIndex")
+	fnUniformBlockBinding = getFunction(gl, "uniformBlockBinding")
 	fnCreateVertexArray = getFunction(gl, "createVertexArray")
 	fnDeleteVertexArray = getFunction(gl, "deleteVertexArray")
 	fnBindVertexArray = getFunction(gl, "bindVertexArray")
@@ -635,6 +643,22 @@ func ClientWaitSync(sync Sync, flags, timeout int) int {
 
 func GetSyncParameter(sync Sync, pname int) int {
 	return fnGetSyncParameter.Invoke(js.Value(sync), pname).Int()
+}
+
+func BindBufferBase(target, index int, buffer Buffer) {
+	fnBindBufferBase.Invoke(target, index, js.Value(buffer))
+}
+
+func BindBufferRange(target, index int, buffer Buffer, offset, size int) {
+	fnBindBufferRange.Invoke(target, index, js.Value(buffer), offset, size)
+}
+
+func GetUniformBlockIndex(program Program, name string) int {
+	return fnGetUniformBlockIndex.Invoke(js.Value(program), name).Int()
+}
+
+func UniformBlockBinding(program Program, index, binding int) {
+	fnUniformBlockBinding.Invoke(js.Value(program), index, binding)
 }
 
 func CreateVertexArray() VertexArray {

--- a/functions.go
+++ b/functions.go
@@ -60,6 +60,7 @@ var (
 	fnFrontFace                js.Value
 	fnGenerateMipmap           js.Value
 	fnGetAttribLocation        js.Value
+	fnGetParameter             js.Value
 	fnGetError                 js.Value
 	fnGetProgramParameter      js.Value
 	fnGetProgramInfoLog        js.Value
@@ -163,6 +164,7 @@ func initFunctions(gl js.Value) {
 	fnFrontFace = getFunction(gl, "frontFace")
 	fnGenerateMipmap = getFunction(gl, "generateMipmap")
 	fnGetAttribLocation = getFunction(gl, "getAttribLocation")
+	fnGetParameter = getFunction(gl, "getParameter")
 	fnGetError = getFunction(gl, "getError")
 	fnGetProgramParameter = getFunction(gl, "getProgramParameter")
 	fnGetProgramInfoLog = getFunction(gl, "getProgramInfoLog")
@@ -406,6 +408,10 @@ func GenerateMipmap(target int) {
 
 func GetAttribLocation(program Program, name string) AttribLocation {
 	return AttribLocation(fnGetAttribLocation.Invoke(js.Value(program), name))
+}
+
+func GetParameter(name int) Result {
+	return Result(fnGetParameter.Invoke(name))
 }
 
 func GetError() int {

--- a/functions.go
+++ b/functions.go
@@ -248,7 +248,7 @@ func GetExtension(name string) interface{} {
 	return true
 }
 
-func ActiveTexture(texture int) {
+func ActiveTexture(texture GLenum) {
 	fnActiveTexture.Invoke(texture)
 }
 
@@ -256,55 +256,55 @@ func AttachShader(program Program, shader Shader) {
 	fnAttachShader.Invoke(js.Value(program), js.Value(shader))
 }
 
-func BindBuffer(target int, buffer Buffer) {
+func BindBuffer(target GLenum, buffer Buffer) {
 	fnBindBuffer.Invoke(target, js.Value(buffer))
 }
 
-func BindFramebuffer(target int, framebuffer Framebuffer) {
+func BindFramebuffer(target GLenum, framebuffer Framebuffer) {
 	fnBindFramebuffer.Invoke(target, js.Value(framebuffer))
 }
 
-func BindTexture(target int, texture Texture) {
+func BindTexture(target GLenum, texture Texture) {
 	fnBindTexture.Invoke(target, js.Value(texture))
 }
 
-func BlendColor(red, green, blue, alpha float32) {
+func BlendColor(red, green, blue, alpha GLclampf) {
 	fnBlendColor.Invoke(red, green, blue, alpha)
 }
 
-func BlendEquationSeparate(modeRGB, modeAlpha int) {
+func BlendEquationSeparate(modeRGB, modeAlpha GLenum) {
 	fnBlendEquationSeparate.Invoke(modeRGB, modeAlpha)
 }
 
-func BlendFunc(sfactor, dfactor int) {
+func BlendFunc(sfactor, dfactor GLenum) {
 	fnBlendFunc.Invoke(sfactor, dfactor)
 }
 
-func BlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha int) {
+func BlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha GLenum) {
 	fnBlendFuncSeparate.Invoke(srcRGB, dstRGB, srcAlpha, dstAlpha)
 }
 
-func CheckFramebufferStatus(target int) int {
-	return fnCheckFramebufferStatus.Invoke(target).Int()
+func CheckFramebufferStatus(target GLenum) GLenum {
+	return GLenum(fnCheckFramebufferStatus.Invoke(target).Int())
 }
 
-func Clear(mask int) {
+func Clear(mask GLbitfield) {
 	fnClear.Invoke(mask)
 }
 
-func ClearColor(r, g, b, a float32) {
+func ClearColor(r, g, b, a GLclampf) {
 	fnClearColor.Invoke(r, g, b, a)
 }
 
-func ClearDepth(depth float32) {
+func ClearDepth(depth GLclampf) {
 	fnClearDepth.Invoke(depth)
 }
 
-func ClearStencil(stencil int) {
+func ClearStencil(stencil GLint) {
 	fnClearStencil.Invoke(stencil)
 }
 
-func ColorMask(r, g, b, a bool) {
+func ColorMask(r, g, b, a GLboolean) {
 	fnColorMask.Invoke(r, g, b, a)
 }
 
@@ -312,7 +312,7 @@ func CompileShader(shader Shader) {
 	fnCompileShader.Invoke(js.Value(shader))
 }
 
-func CopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height int) {
+func CopyTexSubImage2D(target GLenum, level, xoffset, yoffset, x, y GLint, width, height GLsizei) {
 	fnCopyTexSubImage2D.Invoke(target, level, xoffset, yoffset, x, y, width, height)
 }
 
@@ -328,7 +328,7 @@ func CreateProgram() Program {
 	return Program(fnCreateProgram.Invoke())
 }
 
-func CreateShader(shaderType int) Shader {
+func CreateShader(shaderType GLenum) Shader {
 	return Shader(fnCreateShader.Invoke(shaderType))
 }
 
@@ -336,7 +336,7 @@ func CreateTexture() Texture {
 	return Texture(fnCreateTexture.Invoke())
 }
 
-func CullFace(mode int) {
+func CullFace(mode GLenum) {
 	fnCullFace.Invoke(mode)
 }
 
@@ -360,11 +360,11 @@ func DeleteTexture(texture Texture) {
 	fnDeleteTexture.Invoke(js.Value(texture))
 }
 
-func DepthFunc(fn int) {
+func DepthFunc(fn GLenum) {
 	fnDepthFunc.Invoke(fn)
 }
 
-func DepthMask(mask bool) {
+func DepthMask(mask GLboolean) {
 	fnDepthMask.Invoke(mask)
 }
 
@@ -372,27 +372,27 @@ func DetachShader(program Program, shader Shader) {
 	fnDetachShader.Invoke(js.Value(program), js.Value(shader))
 }
 
-func Disable(cap int) {
+func Disable(cap GLenum) {
 	fnDisable.Invoke(cap)
 }
 
-func DisableVertexAttribArray(index int) {
+func DisableVertexAttribArray(index GLuint) {
 	fnDisableVertexAttribArray.Invoke(index)
 }
 
-func DrawArrays(mode, first, count int) {
+func DrawArrays(mode GLenum, first GLint, count GLsizei) {
 	fnDrawArrays.Invoke(mode, first, count)
 }
 
-func DrawElements(mode, count, dtype, offset int) {
+func DrawElements(mode GLenum, count GLsizei, dtype GLenum, offset GLintptr) {
 	fnDrawElements.Invoke(mode, count, dtype, offset)
 }
 
-func Enable(cap int) {
+func Enable(cap GLenum) {
 	fnEnable.Invoke(cap)
 }
 
-func EnableVertexAttribArray(index int) {
+func EnableVertexAttribArray(index GLuint) {
 	fnEnableVertexAttribArray.Invoke(index)
 }
 
@@ -404,15 +404,15 @@ func Flush() {
 	fnFlush.Invoke()
 }
 
-func FramebufferTexture2D(target, attachment, texTarget int, texture Texture, level int) {
+func FramebufferTexture2D(target, attachment, texTarget GLenum, texture Texture, level GLint) {
 	fnFramebufferTexture2D.Invoke(target, attachment, texTarget, js.Value(texture), level)
 }
 
-func FrontFace(mode int) {
+func FrontFace(mode GLenum) {
 	fnFrontFace.Invoke(mode)
 }
 
-func GenerateMipmap(target int) {
+func GenerateMipmap(target GLenum) {
 	fnGenerateMipmap.Invoke(target)
 }
 
@@ -420,15 +420,15 @@ func GetAttribLocation(program Program, name string) GLint {
 	return GLint(fnGetAttribLocation.Invoke(js.Value(program), name).Int())
 }
 
-func GetParameter(name int) Result {
+func GetParameter(name GLenum) Result {
 	return Result(fnGetParameter.Invoke(name))
 }
 
-func GetError() int {
-	return fnGetError.Invoke().Int()
+func GetError() GLenum {
+	return GLenum(fnGetError.Invoke().Int())
 }
 
-func GetProgramParameter(program Program, pname int) Result {
+func GetProgramParameter(program Program, pname GLenum) Result {
 	return Result(fnGetProgramParameter.Invoke(js.Value(program), pname))
 }
 
@@ -436,7 +436,7 @@ func GetProgramInfoLog(program Program) string {
 	return fnGetProgramInfoLog.Invoke(js.Value(program)).String()
 }
 
-func GetShaderParameter(shader Shader, pname int) Result {
+func GetShaderParameter(shader Shader, pname GLenum) Result {
 	return Result(fnGetShaderParameter.Invoke(js.Value(shader), pname))
 }
 
@@ -448,7 +448,7 @@ func GetUniformLocation(program Program, name string) UniformLocation {
 	return UniformLocation(fnGetUniformLocation.Invoke(js.Value(program), name))
 }
 
-func LineWidth(width float32) {
+func LineWidth(width GLfloat) {
 	fnLineWidth.Invoke(width)
 }
 
@@ -456,7 +456,7 @@ func LinkProgram(program Program) {
 	fnLinkProgram.Invoke(js.Value(program))
 }
 
-func Scissor(x, y, width, height int) {
+func Scissor(x, y GLint, width, height GLsizei) {
 	fnScissor.Invoke(x, y, width, height)
 }
 
@@ -464,51 +464,51 @@ func ShaderSource(shader Shader, source string) {
 	fnShaderSource.Invoke(js.Value(shader), source)
 }
 
-func StencilFuncSeparate(face, fun, ref, mask int) {
+func StencilFuncSeparate(face, fun GLenum, ref GLint, mask GLuint) {
 	fnStencilFuncSeparate.Invoke(face, fun, ref, mask)
 }
 
-func StencilMaskSeparate(face, mask int) {
+func StencilMaskSeparate(face GLenum, mask GLuint) {
 	fnStencilMaskSeparate.Invoke(face, mask)
 }
 
-func StencilOpSeparate(face, fail, zfail, zpass int) {
+func StencilOpSeparate(face, fail, zfail, zpass GLenum) {
 	fnStencilOpSeparate.Invoke(face, fail, zfail, zpass)
 }
 
-func TexParameteri(target, pname, param int) {
+func TexParameteri(target, pname GLenum, param GLint) {
 	fnTexParameteri.Invoke(target, pname, param)
 }
 
-func Uniform1f(location UniformLocation, x float32) {
+func Uniform1f(location UniformLocation, x GLfloat) {
 	fnUniform1f.Invoke(js.Value(location), x)
 }
 
-func Uniform2f(location UniformLocation, x, y float32) {
+func Uniform2f(location UniformLocation, x, y GLfloat) {
 	fnUniform2f.Invoke(js.Value(location), x, y)
 }
 
-func Uniform3f(location UniformLocation, x, y, z float32) {
+func Uniform3f(location UniformLocation, x, y, z GLfloat) {
 	fnUniform3f.Invoke(js.Value(location), x, y, z)
 }
 
-func Uniform4f(location UniformLocation, x, y, z, w float32) {
+func Uniform4f(location UniformLocation, x, y, z, w GLfloat) {
 	fnUniform4f.Invoke(js.Value(location), x, y, z, w)
 }
 
-func Uniform1i(location UniformLocation, x int) {
+func Uniform1i(location UniformLocation, x GLint) {
 	fnUniform1i.Invoke(js.Value(location), x)
 }
 
-func Uniform2i(location UniformLocation, x, y int) {
+func Uniform2i(location UniformLocation, x, y GLint) {
 	fnUniform2i.Invoke(js.Value(location), x, y)
 }
 
-func Uniform3i(location UniformLocation, x, y, z int) {
+func Uniform3i(location UniformLocation, x, y, z GLint) {
 	fnUniform3i.Invoke(js.Value(location), x, y, z)
 }
 
-func Uniform4i(location UniformLocation, x, y, z, w int) {
+func Uniform4i(location UniformLocation, x, y, z, w GLint) {
 	fnUniform4i.Invoke(js.Value(location), x, y, z, w)
 }
 
@@ -516,15 +516,15 @@ func UseProgram(program Program) {
 	fnUseProgram.Invoke(js.Value(program))
 }
 
-func VertexAttribPointer(index, size, dtype int, normalized bool, stride, offset int) {
+func VertexAttribPointer(index GLuint, size GLint, dtype GLenum, normalized GLboolean, stride GLsizei, offset GLintptr) {
 	fnVertexAttribPointer.Invoke(index, size, dtype, normalized, stride, offset)
 }
 
-func Viewport(x, y, width, height int) {
+func Viewport(x, y GLint, width, height GLsizei) {
 	fnViewport.Invoke(x, y, width, height)
 }
 
-func BufferData(target, size int, data []byte, usage int) {
+func BufferData(target GLenum, size GLsizeiptr, data []byte, usage GLenum) {
 	if data != nil {
 		pushBufferData(data)
 		fnBufferData.Invoke(target, uint8Array, usage, 0, len(data))
@@ -533,21 +533,21 @@ func BufferData(target, size int, data []byte, usage int) {
 	}
 }
 
-func BufferSubData(target, dstOffset int, data []byte) {
+func BufferSubData(target GLenum, dstOffset GLintptr, data []byte) {
 	pushBufferData(data)
 	fnBufferSubData.Invoke(target, dstOffset, uint8Array, 0, len(data))
 }
 
-func ReadPixels(x, y, width, height, format, dtype, offset int) {
+func ReadPixels(x, y GLint, width, height GLsizei, format, dtype GLenum, offset GLintptr) {
 	fnReadPixels.Invoke(x, y, width, height, format, dtype, offset)
 }
 
-func TexImage2D(target, level, internalFormat, width, height, border, format, dtype int, data []byte) {
+func TexImage2D(target GLenum, level, internalFormat GLint, width, height GLsizei, border GLint, format, dtype GLenum, data []byte) {
 	pushBufferData(data)
 	fnTexImage2D.Invoke(target, level, internalFormat, width, height, border, format, dtype, uint8Array, 0)
 }
 
-func TexSubImage2D(target, level, xoffset, yoffset, width, height, format, dtype int, data []byte) {
+func TexSubImage2D(target GLenum, level, xoffset, yoffset GLint, width, height GLsizei, format, dtype GLenum, data []byte) {
 	pushBufferData(data)
 	switch dtype {
 	case UNSIGNED_BYTE:
@@ -561,75 +561,75 @@ func TexSubImage2D(target, level, xoffset, yoffset, width, height, format, dtype
 	}
 }
 
-func UniformMatrix4fv(location UniformLocation, transpose bool, data []float32) {
+func UniformMatrix4fv(location UniformLocation, transpose GLboolean, data []GLfloat) {
 	pushBufferData(data)
 	fnUniformMatrix4fv.Invoke(js.Value(location), transpose, float32Array, 0, len(data))
 }
 
-func GetBufferSubData[T DataTypes](target, srcOffset int, data []T) {
+func GetBufferSubData[T DataTypes](target GLenum, srcOffset GLintptr, data []T) {
 	length := byteSize(data)
 	ensureBufferSize(length)
 	fnGetBufferSubData.Invoke(target, 0, uint8Array, 0, length)
 	popBufferData(data)
 }
 
-func BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter int) {
+func BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1 GLint, mask GLbitfield, filter GLenum) {
 	fnBlitFramebuffer.Invoke(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter)
 }
 
-func InvalidateFramebuffer(target int, attachments []int) {
+func InvalidateFramebuffer(target GLenum, attachments []GLenum) {
 	ensureSliceSize(len(attachments))
 	view := pushSliceData(attachments, 0)
 	fnInvalidateFramebuffer.Invoke(target, view)
 }
 
-func TexStorage2D(target, levels, internalFormat, width, height int) {
+func TexStorage2D(target GLenum, levels GLsizei, internalFormat GLenum, width, height GLsizei) {
 	fnTexStorage2D.Invoke(target, levels, internalFormat, width, height)
 }
 
-func TexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, dtype int, data []byte) {
+func TexSubImage3D(target GLenum, level GLint, xoffset, yoffset, zoffset GLint, width, height, depth GLsizei, format, dtype GLenum, data []byte) {
 	pushBufferData(data)
 	fnTexSubImage3D.Invoke(target, level, xoffset, yoffset, zoffset, width, height, depth, format, dtype, uint8Array, 0)
 }
 
-func VertexAttribIPointer(index, size, dtype, stride, offset int) {
+func VertexAttribIPointer(index GLuint, size GLint, dtype GLenum, stride GLsizei, offset GLintptr) {
 	fnVertexAttribIPointer.Invoke(index, size, dtype, stride, offset)
 }
 
-func DrawArraysInstanced(mode, first, count, instanceCount int) {
+func DrawArraysInstanced(mode GLenum, first GLint, count, instanceCount GLsizei) {
 	fnDrawArraysInstanced.Invoke(mode, first, count, instanceCount)
 }
 
-func DrawElementsInstanced(mode, count, pType, offset, instanceCount int) {
+func DrawElementsInstanced(mode GLenum, count GLsizei, pType GLenum, offset GLintptr, instanceCount GLsizei) {
 	fnDrawElementsInstanced.Invoke(mode, count, pType, offset, instanceCount)
 }
 
-func DrawBuffers(buffers []int) {
+func DrawBuffers(buffers []GLenum) {
 	ensureSliceSize(len(buffers))
 	view := pushSliceData(buffers, 0)
 	fnDrawBuffers.Invoke(view)
 }
 
-func ClearBufferfv(buffer, drawBuffer int, values []float32) {
+func ClearBufferfv(buffer GLenum, drawBuffer GLint, values Float32List) {
 	pushBufferData(values)
 	fnClearBufferfv.Invoke(buffer, drawBuffer, float32Array)
 }
 
-func ClearBufferiv(buffer, drawBuffer int, values []int32) {
+func ClearBufferiv(buffer GLenum, drawBuffer GLint, values Int32List) {
 	pushBufferData(values)
 	fnClearBufferiv.Invoke(buffer, drawBuffer, int32Array)
 }
 
-func ClearBufferuiv(buffer, drawBuffer int, values []uint32) {
+func ClearBufferuiv(buffer GLenum, drawBuffer GLint, values Uint32List) {
 	pushBufferData(values)
 	fnClearBufferuiv.Invoke(buffer, drawBuffer, uint32Array)
 }
 
-func ClearBufferfi(buffer, drawBuffer int, depth float32, stencil int32) {
+func ClearBufferfi(buffer GLenum, drawBuffer GLint, depth GLfloat, stencil GLint) {
 	fnClearBufferfi.Invoke(buffer, drawBuffer, depth, stencil)
 }
 
-func FenceSync(condition, flags int) Sync {
+func FenceSync(condition GLenum, flags GLbitfield) Sync {
 	return Sync(fnFenceSync.Invoke(condition, flags))
 }
 
@@ -637,27 +637,27 @@ func DeleteSync(sync Sync) {
 	fnDeleteSync.Invoke(js.Value(sync))
 }
 
-func ClientWaitSync(sync Sync, flags, timeout int) int {
-	return fnClientWaitSync.Invoke(js.Value(sync), flags, timeout).Int()
+func ClientWaitSync(sync Sync, flags GLbitfield, timeout GLuint64) GLenum {
+	return GLenum(fnClientWaitSync.Invoke(js.Value(sync), flags, timeout).Int())
 }
 
-func GetSyncParameter(sync Sync, pname int) int {
-	return fnGetSyncParameter.Invoke(js.Value(sync), pname).Int()
+func GetSyncParameter(sync Sync, pname GLenum) Result {
+	return Result(fnGetSyncParameter.Invoke(js.Value(sync), pname))
 }
 
-func BindBufferBase(target, index int, buffer Buffer) {
+func BindBufferBase(target GLenum, index GLuint, buffer Buffer) {
 	fnBindBufferBase.Invoke(target, index, js.Value(buffer))
 }
 
-func BindBufferRange(target, index int, buffer Buffer, offset, size int) {
+func BindBufferRange(target GLenum, index GLuint, buffer Buffer, offset GLintptr, size GLsizeiptr) {
 	fnBindBufferRange.Invoke(target, index, js.Value(buffer), offset, size)
 }
 
-func GetUniformBlockIndex(program Program, name string) int {
-	return fnGetUniformBlockIndex.Invoke(js.Value(program), name).Int()
+func GetUniformBlockIndex(program Program, name string) GLuint {
+	return GLuint(fnGetUniformBlockIndex.Invoke(js.Value(program), name).Int())
 }
 
-func UniformBlockBinding(program Program, index, binding int) {
+func UniformBlockBinding(program Program, index, binding GLuint) {
 	fnUniformBlockBinding.Invoke(js.Value(program), index, binding)
 }
 

--- a/functions.go
+++ b/functions.go
@@ -103,6 +103,7 @@ var (
 	fnInvalidateFramebuffer js.Value
 	fnTexStorage2D          js.Value
 	fnTexSubImage3D         js.Value
+	fnVertexAttribIPointer  js.Value
 	fnDrawArraysInstanced   js.Value
 	fnDrawElementsInstanced js.Value
 	fnDrawBuffers           js.Value
@@ -203,6 +204,7 @@ func initFunctions(gl js.Value) {
 	fnInvalidateFramebuffer = getFunction(gl, "invalidateFramebuffer")
 	fnTexStorage2D = getFunction(gl, "texStorage2D")
 	fnTexSubImage3D = getFunction(gl, "texSubImage3D")
+	fnVertexAttribIPointer = getFunction(gl, "vertexAttribIPointer")
 	fnDrawArraysInstanced = getFunction(gl, "drawArraysInstanced")
 	fnDrawElementsInstanced = getFunction(gl, "drawElementsInstanced")
 	fnDrawBuffers = getFunction(gl, "drawBuffers")
@@ -580,6 +582,10 @@ func TexStorage2D(target, levels, internalFormat, width, height int) {
 func TexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, dtype int, data []byte) {
 	pushBufferData(data)
 	fnTexSubImage3D.Invoke(target, level, xoffset, yoffset, zoffset, width, height, depth, format, dtype, uint8Array, 0)
+}
+
+func VertexAttribIPointer(index, size, dtype, stride, offset int) {
+	fnVertexAttribIPointer.Invoke(index, size, dtype, stride, offset)
 }
 
 func DrawArraysInstanced(mode, first, count, instanceCount int) {

--- a/functions.go
+++ b/functions.go
@@ -416,8 +416,8 @@ func GenerateMipmap(target int) {
 	fnGenerateMipmap.Invoke(target)
 }
 
-func GetAttribLocation(program Program, name string) AttribLocation {
-	return AttribLocation(fnGetAttribLocation.Invoke(js.Value(program), name))
+func GetAttribLocation(program Program, name string) GLint {
+	return GLint(fnGetAttribLocation.Invoke(js.Value(program), name).Int())
 }
 
 func GetParameter(name int) Result {

--- a/types.go
+++ b/types.go
@@ -4,92 +4,157 @@ package wasmgl
 
 import "syscall/js"
 
-var NilAttribLocation = AttribLocation(js.Null())
+type (
+	// GLenum represents the GLenum type from the specification.
+	GLenum = uint32
+	// GLboolean represents the GLboolean type from the specification.
+	GLboolean = bool
+	// GLbitfield represents the GLbitfield type from the specification.
+	GLbitfield = uint32
+	// GLbyte represents the GLbyte type from the specification.
+	GLbyte = int8
+	// GLshort represents the GLshort type from the specification.
+	GLshort = uint16
+	// GLint represents the GLint type from the specification.
+	GLint = int32
+	// GLsizei represents the GLsizei type from the specification.
+	GLsizei = int32
+	// GLintptr represents the GLintptr type from the specification.
+	GLintptr = int64
+	// GLsizeiptr represents the GLsizeiptr type from the specification.
+	GLsizeiptr = int64
+	// GLubyte represents the GLubyte type from the specification.
+	GLubyte = uint8
+	// GLushort represents the GLushort type from the specification.
+	GLushort = uint16
+	// GLuint represents the GLuint type from the specification.
+	GLuint = uint32
+	// GLfloat represents the GLfloat type from the specification.
+	GLfloat = float32
+	// GLclampf represents the GLclampf type from the specification.
+	GLclampf = float32
+)
 
-type AttribLocation js.Value
-
-func (l AttribLocation) IsValid() bool {
-	return isSpecified(js.Value(l))
-}
-
+// NilBuffer equals the zero Buffer.
 var NilBuffer = Buffer(js.Null())
 
+// Buffer represents the WebGLBuffer type from the specification.
 type Buffer js.Value
 
+// IsValid returns whether this Buffer is different from the zero Buffer
+// or an unspecified Buffer.
 func (b Buffer) IsValid() bool {
 	return isSpecified(js.Value(b))
 }
 
+// NilFramebuffer equals the zero Framebuffer.
 var NilFramebuffer = Framebuffer(js.Null())
 
+// Framebuffer represents the WebGLFramebuffer type from the specification.
 type Framebuffer js.Value
 
+// IsValid returns whether this Framebuffer is different from the zero
+// Framebuffer or an unspecified Framebuffer.
 func (f Framebuffer) IsValid() bool {
 	return isSpecified(js.Value(f))
 }
 
+// NilProgram equals the zero Program.
 var NilProgram = Program(js.Null())
 
+// Program represents the WebGLProgram type from the specification.
 type Program js.Value
 
+// IsValid returns whether this Program is different from the zero Program or
+// an unspecified Program.
 func (p Program) IsValid() bool {
 	return isSpecified(js.Value(p))
 }
 
-var NilResult = Result(js.Null())
-
+// Result represents an undefined return type. In the specification this is
+// indicated with the `any` keyword.
 type Result js.Value
 
+// IsValid returns whether this Result is specified and can be used.
 func (r Result) IsValid() bool {
 	return isSpecified(js.Value(r))
 }
 
-func (r Result) Bool() bool {
+// GLboolean returns the contents of this Result as a GLboolean type.
+func (r Result) GLboolean() GLboolean {
 	return js.Value(r).Bool()
 }
 
-func (r Result) Int() int {
-	return js.Value(r).Int()
+// GLenum returns the contents of this Result as a GLenum type.
+func (r Result) GLenum() GLenum {
+	return GLenum(js.Value(r).Int())
 }
 
+// GLint returns the contents of this Result as a GLint type.
+func (r Result) GLint() GLint {
+	return GLint(js.Value(r).Int())
+}
+
+// NilShader equals the zero Shader.
 var NilShader = Shader(js.Null())
 
+// Shader represents the WebGLShader type from the specification.
 type Shader js.Value
 
+// IsValid returns whether this Shader is different from the zero Shader or
+// an unspecified Shader.
 func (s Shader) IsValid() bool {
 	return isSpecified(js.Value(s))
 }
 
+// NilSync equals the zero Sync.
+var NilSync = Sync(js.Null())
+
+// Sync represents the WebGLSync type from the specification.
+type Sync js.Value
+
+// IsValid returns whether this Sync is different from the zero Sync or an
+// unspecified Sync.
+func (s Sync) Valid() bool {
+	return isSpecified(js.Value(s))
+}
+
+// NilTexture equals the zero Texture.
 var NilTexture = Texture(js.Null())
 
+// Texture represents the WebGLTexture type from the specification.
 type Texture js.Value
 
+// IsValid returns whether this Texture is different from the zero Texture or
+// an unspecified Texture.
 func (t Texture) IsValid() bool {
 	return isSpecified(js.Value(t))
 }
 
+// NilUniformLocation equals the nil UniformLocation.
 var NilUniformLocation = UniformLocation(js.Null())
 
+// UniformLocation represents the WebGLUniformLocation type from the
+// specification.
 type UniformLocation js.Value
 
+// IsValid returns whether this UniformLocation is different from the nil
+// UniformLocation or an unspecified UniformLocation.
 func (l UniformLocation) IsValid() bool {
 	return isSpecified(js.Value(l))
 }
 
+// NilVertexArray equals the zero VertexArray.
 var NilVertexArray = VertexArray(js.Null())
 
+// VertexArray represents the WebGLVertexArrayObject type from the
+// specification.
 type VertexArray js.Value
 
+// IsValid returns whether this VertexArray is different from the zero
+// VertexArray or an unspecified VertexArray.
 func (a VertexArray) IsValid() bool {
 	return isSpecified(js.Value(a))
-}
-
-var NilSync = Sync(js.Null())
-
-type Sync js.Value
-
-func (s Sync) Valid() bool {
-	return isSpecified(js.Value(s))
 }
 
 func isSpecified(jsValue js.Value) bool {

--- a/types.go
+++ b/types.go
@@ -33,6 +33,17 @@ type (
 	GLfloat = float32
 	// GLclampf represents the GLclampf type from the specification.
 	GLclampf = float32
+	// GLint64 represents the GLint64 type from the specification.
+	GLint64 = int64
+	// GLuint64 represents the GLuint64 type from the specification.
+	GLuint64 = uint64
+
+	// Float32List represents the Float32List type from the specification.
+	Float32List = []float32
+	// Int32List represents the Int32List type from the specification.
+	Int32List = []int32
+	// Uint32List represents the Uint32List type from the specification.
+	Uint32List = []uint32
 )
 
 // NilBuffer equals the zero Buffer.


### PR DESCRIPTION
This PR adjusts the parameters of WebGL functions to accept concrete integer types as per the specification. This should prevent some potential bugs and should make it easier to follow.

**NOTE:** Keep in mind that this is a breaking change.

In addition, this PR adds functions related to Uniform Buffer Objects.
